### PR TITLE
fix `scale`  InvalidParameterType: Expected params.DesiredCapacity to be a number

### DIFF
--- a/lib/aws/scaleAutoScalingGroup.js
+++ b/lib/aws/scaleAutoScalingGroup.js
@@ -7,7 +7,9 @@ const autoscaling = new AWS.AutoScaling({
 function scaleInstances(name, amount) {
     const params = {
         AutoScalingGroupName: name,
-        DesiredCapacity: amount
+        DesiredCapacity: amount.desired,
+        MaxSize: amount.max,
+        MinSize: amount.min
     };
 
     return autoscaling.updateAutoScalingGroup(params).promise();


### PR DESCRIPTION
when calling:

```
aws-autoscale-deployer scale -m 2 -M 2 -d 2 "AutoScaler"
```

it throws an exception:

```
{ InvalidParameterType: Expected params.DesiredCapacity to be a number
    at ParamValidator.fail (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:50:37)
    at ParamValidator.validateType (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:218:10)
    at ParamValidator.validateNumber (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:229:14)
    at ParamValidator.validateScalar (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:136:21)
    at ParamValidator.validateMember (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:94:21)
    at ParamValidator.validateStructure (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:75:14)
    at ParamValidator.validateMember (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:88:21)
    at ParamValidator.validate (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/param_validator.js:34:10)
    at Request.VALIDATE_PARAMETERS (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/event_listeners.js:108:42)
    at Request.callListeners (/usr/local/lib/node_modules/@tlrg/aws-autoscale-deployer/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
  message: 'Expected params.DesiredCapacity to be a number',
  code: 'InvalidParameterType',
  time: 2017-03-03T10:55:52.239Z }

```

changes params according to docs: http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_UpdateAutoScalingGroup.html